### PR TITLE
[Release] Updated `setup.py` for PyPi meta data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,18 +23,18 @@ import shutil
 
 # Setup variables. Change as needed
 NAME = "mapillary"
-VERSION = "0.0.1"
-AUTHOR = "Christopher Beddow, Omar Ali, Saif Ul Islam"
-AUTHOR_EMAIL = "cbed@fb.com, omarmuhammed1998.om@gmail.com, saifulislam84210@gmail.com"
+VERSION = "0.0.17"
+AUTHOR = "Christopher Beddow"
+AUTHOR_EMAIL = "support@mapillary.zendesk.com"
 LICENSE = "MIT"
-PLATFORM = "any"
+PLATFORM = ["POSIX", "MacOS X", "Linux", "Windows"]
 DESCRIPTION = (
     "A Python 3 library built on the Mapillary API v4 to facilitate retrieving and "
     "working with Mapillary data"
 )
 LONG_DESCRIPTION_CONTENT_TYPE = "text/markdown"
 URL = "https://github.com/mapillary/mapillary-python-sdk"
-REQUIRES_PYTHON = ">3.0"
+REQUIRES_PYTHON = ">=3.0"
 HERE = os.path.abspath(os.path.dirname(__file__))
 REQUIREMENTS = [
     "mercantile",
@@ -50,7 +50,12 @@ CLASSIFIERS = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: GIS",
     "Topic :: Scientific/Engineering :: Information Analysis",
+    "Natural Language :: English",
     "Operating System :: OS Independent",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: Microsoft",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
@@ -61,11 +66,14 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.9",
 ]
 PROJECT_URLS = {
+    "Download": "https://pypi.org/project/mapillary/#files",
+    "Release Notes": "https://github.com/mapillary/mapillary-python-sdk/releases",
     "Bug Tracker": "https://github.com/mapillary/mapillary-python-sdk/issues",
-    # "Support Email": "support@mapillary.zendesk.com",
+    "Source": "https://github.com/mapillary/mapillary-python-sdk",
+    "Twitter": "https://twitter.com/mapillary",
+    "Developer Resources": "https://www.mapillary.com/developer",
     "Community Forum": "https://forum.mapillary.com/",
     "Blog": "https://blog.mapillary.com/",
-    "Twitter": "https://twitter.com/mapillary",
     "Facebook": "https://www.facebook.com/mapillary/",
     "Website": "https://www.mapillary.com/",
 }


### PR DESCRIPTION
Introduced minor changes after reading more about PyPI,
- I cannot add multiple authors in `AUTHORS`, so I kept it to "Christopher Beddow" only
- Platforms can introduce more than one OS, thus I changed `str` to `list`
- More classifiers are introduced for better search on http://pypi.org/
- More relevant URLs are added after looking at other PyPi packages

@cbeddow minor changes I thought were useful. These changes are reflected right now at https://pypi.org/project/mapillary/.

Signed-off-by: Saif Ul Islam <saifulislam84210@gmail.com>