### PR TITLE
Fix 403 auth error for tiles endpoints

### DIFF
--- a/src/mapillary/models/client.py
+++ b/src/mapillary/models/client.py
@@ -177,7 +177,7 @@ class Client:
 
         return res
 
-    def get(self, url: str = None, params: dict = None):
+    def get(self, url: str = None, params: dict = {}):
         """
         Make GET requests to both mapillary main endpoints
 
@@ -191,8 +191,12 @@ class Client:
         if url is None:
             logger.error("You need to specify an endpoint!")
             return
-
-        self.session.headers.update({"Authorization": f"OAuth {self.__access_token}"})
+        
+        # Determine Authentication method based on the requested endpoint
+        if "https://graph.mapillary.com" in url:
+            self.session.headers.update({"Authorization": f"OAuth {self.__access_token}"})
+        else:
+            params['access_token'] = params.get('access_token', self.__access_token)
 
         return self._initiate_request(url=url, method="GET", params=params)
 


### PR DESCRIPTION
Closing #131 and #124 

### Approach taken
Checks whether the requested endpoint is a `tiles` or a `graph` endpoint, and changes authentication method accordingly. 