### PR TITLE
Fix a crash in get_image_close_to when a tile has no features

### DIFF
--- a/src/mapillary/controller/image.py
+++ b/src/mapillary/controller/image.py
@@ -112,7 +112,7 @@ def get_image_close_to_controller(
 
     # Filtering for the attributes obtained above
     if (
-        unfiltered_data["features"] != {}
+        len(unfiltered_data["features"]) != 0
         and unfiltered_data["features"][0]["properties"] != {}
     ):
         return GeoJSON(


### PR DESCRIPTION
Tiny bugfix; When calling get_image_close_to, the library would crash when the received tile was empty, with a message like this:

```
  File "/usr/local/lib/python3.9/site-packages/mapillary/utils/auth.py", line 59, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/mapillary/interface.py", line 110, in get_image_close_to
    return image.get_image_close_to_controller(
  File "/usr/local/lib/python3.9/site-packages/mapillary/controller/image.py", line 134, in get_image_close_to_controller
    and unfiltered_data["features"][0]["properties"] != {}
IndexError: list index out of range
```

this MR fixes this crash.