### PR TITLE
Rubix982/api changes and refactoring

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,153 @@
+@echo off
+
+
+IF /I "%1"=="def skip(app, what, name, obj, would_skip, options)" GOTO def skip(app, what, name, obj, would_skip, options)
+IF /I "%1"=="    if name in ('__init__',)" GOTO     if name in ('__init__',)
+IF /I "%1"=="    def setup(app)" GOTO     def setup(app)
+IF /I "%1"=="setup" GOTO setup
+IF /I "%1"=="setup-prod" GOTO setup-prod
+IF /I "%1"=="setup-dev" GOTO setup-dev
+IF /I "%1"=="build" GOTO build
+IF /I "%1"=="local-install" GOTO local-install
+IF /I "%1"=="style" GOTO style
+IF /I "%1"=="format" GOTO format
+IF /I "%1"=="lint" GOTO lint
+IF /I "%1"=="docs-gen" GOTO docs-gen
+IF /I "%1"=="docs-sphinx" GOTO docs-sphinx
+IF /I "%1"=="docs-py" GOTO docs-py
+IF /I "%1"=="docs-start" GOTO docs-start
+IF /I "%1"=="docs-push" GOTO docs-push
+IF /I "%1"=="docs-build" GOTO docs-build
+IF /I "%1"=="docs-deploy" GOTO docs-deploy
+IF /I "%1"=="clean" GOTO clean
+IF /I "%1"=="sphinx-docs-clean" GOTO sphinx-docs-clean
+IF /I "%1"=="docs-clean" GOTO docs-clean
+IF /I "%1"=="build-clean" GOTO build-clean
+IF /I "%1"=="dump-clean" GOTO dump-clean
+IF /I "%1"=="test" GOTO test
+IF /I "%1"=="test-no-warn" GOTO test-no-warn
+GOTO error
+
+:def skip(app, what, name, obj, would_skip, options)
+	'''Skip'''
+	GOTO :EOF
+
+:    if name in ('__init__',)
+	return False
+	return would_skip
+	GOTO :EOF
+
+:    def setup(app)
+	'''Setup App'''
+	GOTO :EOF
+
+:setup
+	CALL make.bat setup-prod
+	CALL make.bat setup-dev
+	GOTO :EOF
+
+:setup-prod
+	python -m pip install --upgrade pip
+	pip install pipenv
+	pipenv install
+	GOTO :EOF
+
+:setup-dev
+	python -m pip install --upgrade pip
+	pip install pipenv
+	pipenv install --dev
+	GOTO :EOF
+
+:build
+	pipenv run python3 setup.py sdist bdist_wheel --universal
+	GOTO :EOF
+
+:local-install
+	pipenv run pip3 install -e .
+	GOTO :EOF
+
+:style
+	CALL make.bat format
+	CALL make.bat lint
+	GOTO :EOF
+
+:format
+	@ black src/mapillary
+	@ black tests/
+	GOTO :EOF
+
+:lint
+	@
+	@ flake8 src/mapillary --count --select=E9,F63,F7,F82 --show-source --statistics
+	@ flake8 tests/ --count --select=E9,F63,F7,F82 --show-source --statistics
+	GOTO :EOF
+
+:docs-gen
+	CALL make.bat docs-sphinx
+	CALL make.bat docs-py
+	CALL make.bat docs-start
+	GOTO :EOF
+
+:docs-sphinx
+	sphinx-apidoc -o sphinx-docs ./src/ sphinx-apidoc --full -A 'Mapillary'; cd sphinx-docs; echo "$$PYTHON_SCRIPT" >> conf.py; make markdown;
+	GOTO :EOF
+
+:docs-py
+	python3 scripts/documentation.py
+	GOTO :EOF
+
+:docs-start
+	PUSHD docs; npm run start; && POPD
+	GOTO :EOF
+
+:docs-push
+	CALL make.bat docs-build
+	CALL make.bat docs-deploy
+	GOTO :EOF
+
+:docs-build
+	PUSHD docs; npm run build; && POPD
+	GOTO :EOF
+
+:docs-deploy
+	PUSHD docs; GIT_USER=Rubix982 yarn deploy; && POPD
+	GOTO :EOF
+
+:clean
+	CALL make.bat sphinx-docs-clean
+	CALL make.bat docs-clean
+	CALL make.bat build-clean
+	CALL make.bat dump-clean
+	GOTO :EOF
+
+:sphinx-docs-clean
+	DEL /Q sphinx-docs/ -rf
+	GOTO :EOF
+
+:docs-clean
+	DEL /Q docs/build -rf
+	GOTO :EOF
+
+:build-clean
+	DEL /Q build/ dist/ -rf
+	GOTO :EOF
+
+:dump-clean
+	DEL /Q tests/dump/ -rf
+	GOTO :EOF
+
+:test
+	@ pytest --log-cli-level=20
+	GOTO :EOF
+
+:test-no-warn
+	@ pytest --log-cli-level=20 --disable-warnings
+	GOTO :EOF
+
+:error
+    IF "%1"=="" (
+        ECHO make: *** No targets specified and no makefile found.  Stop.
+    ) ELSE (
+        ECHO make: *** No rule to make target '%1%'. Stop.
+    )
+    GOTO :EOF

--- a/src/mapillary/config/api/entities.py
+++ b/src/mapillary/config/api/entities.py
@@ -15,12 +15,21 @@ For more information, please check out https://www.mapillary.com/developer/api-d
 """
 
 # Local imports
-
-# # Exception Handling
-from mapillary.models.exceptions import InvalidFieldError, InvalidNumberOfArguments
-
-# # Imports
+import datetime
+import logging
 import typing
+
+# # Utils
+from mapillary.utils.time import is_iso8601_datetime_format
+
+# # Models
+# # # Exception Handling
+from mapillary.models.exceptions import InvalidFieldError, InvalidNumberOfArguments
+from mapillary.models.config import Config
+from mapillary.models.logger import Logger
+
+logger: logging.Logger = Logger.setup_logger(name="mapillary.config.api.entities")
+
 
 class Entities:
     """
@@ -90,7 +99,9 @@ class Entities:
         return f"https://graph.mapillary.com/{image_id}/?fields={','.join(fields)}"
 
     @staticmethod
-    def get_images(image_ids: typing.List[str], fields: list) -> str:
+    def get_images(
+        image_ids: typing.Union[typing.List[str], typing.List[int]], fields: list
+    ) -> str:
         """
         Represents the metadata of the image on the Mapillary platform with
         the following properties.
@@ -101,7 +112,8 @@ class Entities:
 
         Parameters::
 
-            A list of entity IDs separated by comma. The provided IDs must be in the same type (e.g. all image IDs, or all detection IDs)
+            A list of entity IDs separated by comma. The provided IDs must be in the same type
+            (e.g. all image IDs, or all detection IDs)
 
         Fields::
 
@@ -130,7 +142,7 @@ class Entities:
             22. width - int, width of the original image uploaded
 
         Raises::
-            
+
             InvalidNumberOfArguments - if the number of ids passed is 0 or greater than 50
         """
 
@@ -140,7 +152,11 @@ class Entities:
         # in the future
 
         if len(image_ids) == 0 or len(image_ids) > 50:
-            raise InvalidNumberOfArguments(number_of_params_passed=len(image_ids), actual_allowed_params=50, param="image_ids")
+            raise InvalidNumberOfArguments(
+                number_of_params_passed=len(image_ids),
+                actual_allowed_params=50,
+                param="image_ids",
+            )
 
         fields = Entities.__field_validity(
             given_fields=fields,
@@ -149,6 +165,193 @@ class Entities:
         )
 
         return f"https://graph.mapillary.com/ids={','.join(image_ids)}?fields={','.join(fields)}"
+
+    @staticmethod
+    def search_for_images(  # noqa: C901, 'search_for_images is too complex'
+        bbox: typing.List[float],
+        start_captured_at: typing.Optional[datetime.datetime] = None,
+        end_captured_at: typing.Optional[datetime.datetime] = None,
+        limit: typing.Optional[int] = None,
+        organization_id: typing.Union[
+            typing.Optional[int], typing.Optional[str]
+        ] = None,
+        sequence_id: typing.Optional[typing.List[int]] = None,
+        fields: typing.Optional[list] = [],
+    ) -> str:
+        """
+        Represents the metadata of the image on the Mapillary platform with
+        the following properties.
+
+        Output Format::
+
+            >>> 'https://graph.mapillary.com/search?bbox=LONG1,LAT1,LONG2,LAT2' # endpoint
+            >>> 'https://graph.mapillary.com/search?bbox=LONG1,LAT1,LONG2,LAT2&start_time='
+            'START_TIME' # endpoint
+            >>> 'https://graph.mapillary.com/search?bbox=LONG1,LAT1,LONG2,LAT2&start_time='
+            'START_TIME&end_time=END_TIME' # endpoint
+            >>> 'https://graph.mapillary.com/search?bbox=LONG1,LAT1,LONG2,LAT2&start_time='
+            'START_TIME&end_time=END_TIME&limit=LIMIT' # endpoint
+            >>> 'https://graph.mapillary.com/search/images?bbox=LONG1,LAT1,LONG2,LAT2&start_time'
+            '=START_TIME&end_time=END_TIME&limit=LIMIT&organization_id=ORGANIZATION_ID&'
+            'sequence_id=SEQUENCE_ID1' # endpoint
+            >>> 'https://graph.mapillary.com/search/images?bbox=LONG1,LAT1,LONG2,LAT2&start_time='
+            'START_TIME&end_time=END_TIME&limit=LIMIT&organization_id=ORGANIZATION_ID&sequence_id'
+            '=SEQUENCE_ID1,SEQUENCE_ID2,SEQUENCE_ID3' # endpoint
+
+        Usage::
+
+            >>> from mapillary.config.api.entities import Entities
+            >>> bbox = [-180, -90, 180, 90]
+            >>> start_captured_at = datetime.datetime(2020, 1, 1, 0, 0, 0)
+            >>> end_captured_at = datetime.datetime(2022, 1, 1, 0, 0, 0)
+            >>> organization_id = 123456789
+            >>> sequence_ids = [123456789, 987654321]
+            >>> Entities.search_for_images(bbox=bbox) # endpoint
+            'https://graph.mapillary.com/search?bbox=-180,-90,180,90' # endpoint
+            >>> Entities.search_for_images(bbox=bbox, start_captured_at=start_captured_at)
+            'https://graph.mapillary.com/search?bbox=-180,-90,180,90&start_time=' # endpoint
+            >>> Entities.search_for_images(bbox=bbox,
+            ... start_captured_at=start_captured_at, end_captured_at=end_captured_at)
+            'https://graph.mapillary.com/search?bbox=-180,-90,180,90&start_time=&'
+            'end_time=' # endpoint
+            >>> Entities.search_for_images(bbox=bbox,
+            ... start_captured_at=start_captured_at, end_captured_at=end_captured_at,
+            ... limit=100)
+            'https://graph.mapillary.com/search?bbox=-180,-90,180,90&start_time=&end_time=&limit'
+            '=100' # endpoint
+            >>> Entities.search_for_images(bbox=bbox,
+            ... start_captured_at=start_captured_at, end_captured_at=end_captured_at,
+            ... limit=100, organization_id=organization_id, sequence_id=sequence_ids)
+            'https://graph.mapillary.com/search/images?bbox=-180,-90,180,90&start_time=&end_time'
+            '=&limit=100&organization_id=1234567890&sequence_id=1234567890' # endpoint
+
+        :param bbox: float,float,float,float: filter images in the bounding box. Specify in this
+        order: left, bottom, right, top (or minLon, minLat, maxLon, maxLat).
+        :type bbox: typing.Union[typing.List[float], typing.Tuple[float, float, float, float],
+        list, tuple]
+
+        :param start_captured_at: filter images captured after. Specify in the ISO 8601 format.
+        For example: "2022-08-16T16:42:46Z".
+        :type start_time: typing.Union[typing.Optional[datetime.datetime], typing.Optional[str]]
+        :default start_captured_at: None
+
+        :param end_captured_at: filter images captured before. Same format as
+        "start_captured_at".
+        :type end_time: typing.Union[typing.Optional[datetime.datetime], typing.Optional[str]]
+        :default end_captured_at: None
+
+        :param limit: limit the number of images returned. Max and default is 2000. The 'default'
+        here means the default value of `limit` assumed on the server's end if the limit param
+        is not passed. In other words, if the `limit` parameter is set to `None`, the server will
+        assume the `limit` parameter to be 2000, which is the same as setting the `limit`
+        parameter to 2000 explicitly.
+        :type limit: typing.Optional[int]
+        :default limit: None
+
+        :param organization_id: filter images contributed to the specified organization Id.
+        :type organization_id: typing.Optional[int]
+        :default organization_id: None
+
+        :param sequence_id: filter images in the specified sequence Ids (separated by commas),
+        For example, "[1234567890,1234567891,1234567892]".
+        :type sequence_id: typing.Optional[typing.List[int], int]
+        :default sequence_id: None
+
+        :param fields: filter the fields returned. For example, "['atomic_scale', 'altitude',
+        'camera_parameters']". For more information, see
+        https://www.mapillary.com/developer/api-documentation/#image. To get list of all possible
+        fields, please use Entities.get_image_fields()
+        :type fields: typing.Optional[typing.List[str]]
+        :default fields: []
+
+        :return: endpoint for searching an image
+        :rtype: str
+        """
+
+        fields = Entities.__field_validity(
+            given_fields=fields,
+            actual_fields=Entities.get_image_fields(),
+            endpoint="https://graph.mapillary.com/images?bbox=,:parameters=,:fields=",
+        )
+
+        parameter_string: str = ""
+
+        parameters = {
+            "start_captured_at": start_captured_at,
+            "end_captured_at": end_captured_at,
+            "limit": limit,
+            "organization_id": organization_id,
+            "sequence_id": sequence_id,
+        }
+
+        # For each item in the given parameters ...
+        for key, value in parameters.items():
+
+            # ... if it is not None ...
+            if value is not None:
+
+                # ... if the key is about time ...
+                if key in ["start_captured_at", "end_captured_at"]:
+
+                    # ... if the datatype is a string ...
+                    if isinstance(value, str):
+
+                        # ... check if the string is a valid datetime in the ISO8601 format ...
+                        if not is_iso8601_datetime_format(value) and Config.use_strict:
+
+                            # ... if not, raise an error ...
+                            if Config.use_strict:
+
+                                # Raising ValueError if strict mode is enabled
+                                raise ValueError(
+                                    f"""{key} must be in the ISO 8601 format. For example:
+                                    '2022-08-16T16:42:46Z'."""
+                                )
+
+                            else:
+
+                                logger.warning(
+                                    f"{key} must be in the ISO 8601 format. For example:"
+                                    f"'2022-08-16T16:42:46Z'. Disregarding {key} parameter."
+                                    "Continuing without strict mode enabled."
+                                )
+
+                            # ... if not, just move on - no assumptions on the `date string` ...
+                            continue
+
+                    # ... if the value is a valid datetime object ...
+                    elif isinstance(value, datetime.datetime):
+
+                        # ... convert it to the ISO 8601 format required ...
+                        value = value.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+                # ... if the key is limit ...
+                if key == "limit":
+
+                    # Check if it is within limits
+                    if value > 2000:
+
+                        # Log warning if not, waring mode is enabled - logger object declared
+                        # globally is used
+                        logger.warning(f"{key} is greater than 2000. Setting to 2000.")
+
+                        # Set the value to 2000
+                        value = 2000
+
+                # ... if the key is sequence_id ...
+                if key == "sequence_id":
+                    # ... convert the list into string ...
+                    value = ",".join(map(str, value))
+
+                # ... add it to the parameter string
+                parameter_string += f"&{key}={value}"
+
+        # Return the endpoint
+        return (
+            f"https://graph.mapillary.com/images?bbox={','.join([str(val) for val in bbox])}"
+            f"{parameter_string if parameter_string != '' else ''}"
+            f"{'&fields=' + ','.join(fields) if fields != [] else ''}"
+        )
 
     @staticmethod
     def get_image_fields() -> list:
@@ -402,6 +605,9 @@ class Entities:
         :return: The given_fields if everything is correct
         :rtype: list
         """
+
+        if len(given_fields) == 0:
+            return given_fields  # empty list: []
 
         # Converting the given_fields into lowercase
         given_fields = [field.lower() for field in given_fields]

--- a/src/mapillary/config/api/entities.py
+++ b/src/mapillary/config/api/entities.py
@@ -17,8 +17,10 @@ For more information, please check out https://www.mapillary.com/developer/api-d
 # Local imports
 
 # # Exception Handling
-from mapillary.models.exceptions import InvalidFieldError
+from mapillary.models.exceptions import InvalidFieldError, InvalidNumberOfArguments
 
+# # Imports
+import typing
 
 class Entities:
     """
@@ -86,6 +88,67 @@ class Entities:
         )
 
         return f"https://graph.mapillary.com/{image_id}/?fields={','.join(fields)}"
+
+    @staticmethod
+    def get_images(image_ids: typing.List[str], fields: list) -> str:
+        """
+        Represents the metadata of the image on the Mapillary platform with
+        the following properties.
+
+        Usage::
+
+            >>> 'https://graph.mapillary.com/ids=ID1,ID2,ID3' # endpoint
+
+        Parameters::
+
+            A list of entity IDs separated by comma. The provided IDs must be in the same type (e.g. all image IDs, or all detection IDs)
+
+        Fields::
+
+            1. altitude - float, original altitude from Exif
+            2. atomic_scale - float, scale of the SfM reconstruction around the image
+            3. camera_parameters - array of float, intrinsic camera parameters
+            4. camera_type - enum, type of camera projection (perspective, fisheye, or spherical)
+            5. captured_at - timestamp, capture time
+            6. compass_angle - float, original compass angle of the image
+            7. computed_altitude - float, altitude after running image processing
+            8. computed_compass_angle - float, compass angle after running image processing
+            9. computed_geometry - GeoJSON Point, location after running image processing
+            10. computed_rotation - enum, corrected orientation of the image
+            11. exif_orientation - enum, orientation of the camera as given by the exif tag
+                (see: https://sylvana.net/jpegcrop/exif_orientation.html)
+            12. geometry - GeoJSON Point geometry
+            13. height - int, height of the original image uploaded
+            14. thumb_256_url - string, URL to the 256px wide thumbnail
+            15. thumb_1024_url - string, URL to the 1024px wide thumbnail
+            16. thumb_2048_url - string, URL to the 2048px wide thumbnail
+            17. merge_cc - int, id of the connected component of images that were aligned together
+            18. mesh - { id: string, url: string } - URL to the mesh
+            19. quality_score - float, how good the image is (experimental)
+            20. sequence - string, ID of the sequence
+            21. sfm_cluster - { id: string, url: string } - URL to the point cloud
+            22. width - int, width of the original image uploaded
+
+        Raises::
+            
+            InvalidNumberOfArguments - if the number of ids passed is 0 or greater than 50
+        """
+
+        # TODO: while this function should not be responsible to check if
+        # all of the IDs passed are image_ids or detections_ids, this comment
+        # should be to remind that this logic should belong elsewhere or to integrated
+        # in the future
+
+        if len(image_ids) == 0 or len(image_ids) > 50:
+            raise InvalidNumberOfArguments(number_of_params_passed=len(image_ids), actual_allowed_params=50, param="image_ids")
+
+        fields = Entities.__field_validity(
+            given_fields=fields,
+            actual_fields=Entities.get_image_fields(),
+            endpoint="https://graph.mapillary.com/ids=",
+        )
+
+        return f"https://graph.mapillary.com/ids={','.join(image_ids)}?fields={','.join(fields)}"
 
     @staticmethod
     def get_image_fields() -> list:

--- a/src/mapillary/config/api/entities.py
+++ b/src/mapillary/config/api/entities.py
@@ -297,7 +297,7 @@ class Entities:
                     if isinstance(value, str):
 
                         # ... check if the string is a valid datetime in the ISO8601 format ...
-                        if not is_iso8601_datetime_format(value) and Config.use_strict:
+                        if not is_iso8601_datetime_format(value):
 
                             # ... if not, raise an error ...
                             if Config.use_strict:

--- a/src/mapillary/interface.py
+++ b/src/mapillary/interface.py
@@ -23,6 +23,7 @@ from mapillary.utils.auth import auth, set_token
 
 # Models
 from mapillary.models.geojson import Coordinates, GeoJSON
+from mapillary.models.config import Config
 
 # Exception classes
 from mapillary.models.exceptions import InvalidOptionError
@@ -32,6 +33,35 @@ import mapillary.controller.image as image
 import mapillary.controller.feature as feature
 import mapillary.controller.detection as detection
 import mapillary.controller.save as save
+
+
+def configure_mapillary_settings(**kwargs):
+    """
+    A function allowing the user to configure the Mapillary settings for the session. Takes no
+    arguments and sets a global variable used by other functions making API requests. For more
+    information what the details of authentication, please check out the blog post at Mapillary.
+    https://blog.mapillary.com/update/2021/06/23/getting-started-with-the-new-mapillary-api-v4.html
+
+    :return: None
+    :rtype: None
+
+    Usage::
+
+        >>> import mapillary as mly
+        >>> mly.interface.configure_mapillary_settings()
+        >>> mly.interface.configure_mapillary_settings(use_strict=True)
+
+    :param kwargs: Keyword arguments for the configuration
+    :type kwargs: dict
+
+    :param kwargs.use_strict: Whether to use strict mode or not
+    :type kwargs.use_strict: bool
+
+    :return: None
+    :rtype: None
+    """
+
+    return Config(kwargs)
 
 
 def set_access_token(token: str):

--- a/src/mapillary/models/__init__.py
+++ b/src/mapillary/models/__init__.py
@@ -15,3 +15,5 @@ from . import client  # noqa: F401
 from . import exceptions  # noqa: F401
 from . import geojson  # noqa: F401
 from . import api  # noqa: F401
+from . import logger  # noqa: F401
+from . import config # noqa: F401

--- a/src/mapillary/models/config.py
+++ b/src/mapillary/models/config.py
@@ -1,0 +1,50 @@
+# Copyright (c) Facebook, Inc. and its affiliates. (http://www.facebook.com)
+# -*- coding: utf-8 -*-
+
+"""
+mapillary.models.config
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+This module contains the Config class which sets up some global variables fo the duration of
+the session that the SDK is in use for.
+
+For more information, please check out https://www.mapillary.com/developer/api-documentation/.
+
+- Copyright: (c) 2021 Facebook
+- License: MIT License
+"""
+
+from mapillary.models.logger import Logger
+
+Logger.setup_logger(name="mapillary.models.config")
+
+
+class Config:
+    """
+    Config setup for the SDK
+
+    Different parts of the SDK react differently depending on what is set
+
+    Usage::
+
+        >>> from mapillary.models.config import Config
+
+    :param use_strict: If set to True, the SDK will raise an exception if an invalid arguments
+    are sent to the functions in config.api calls. If set to False, the SDK will just log a warning.
+    :type use_strict: bool
+    :default use_strict: True
+    """
+
+    # Strict mode will raise exceptions when,
+    # 1. Invalid arguments are passed to a function, such as those
+    # files in the config.api directory. This can mean invalid date
+    # formats, invalid IDs, invalid data types, etc.
+
+    use_strict = True
+
+    def __init__(self, use_strict: bool = True) -> None:
+        """
+        Initialize the Config class
+        """
+
+        self.use_strict = use_strict

--- a/src/mapillary/models/exceptions.py
+++ b/src/mapillary/models/exceptions.py
@@ -356,12 +356,19 @@ class LiteralEnforcementException(MapillaryException):
                 param=param, value=option_selected, options=options
             )
 
+
 class InvalidNumberOfArguments(MapillaryException):
     """
     Raised when an inappropriate number of parameters are passed to a function
     """
 
-    def __init__(self, number_of_params_passed: int, actual_allowed_params: int, param: str,  *args: object) -> None:
+    def __init__(
+        self,
+        number_of_params_passed: int,
+        actual_allowed_params: int,
+        param: str,
+        *args: object,
+    ) -> None:
         super().__init__(*args)
 
         self.number_of_params_passed = number_of_params_passed
@@ -371,8 +378,12 @@ class InvalidNumberOfArguments(MapillaryException):
     def __str__(self):
         return (
             f'InvalidNumberOfArguments: The parameter, "{self.param}" was '
-            f'passed "{self.number_of_params_passed}" items, when the max number of allowed items are "{self.actual_allowed_params}"'
+            f'passed "{self.number_of_params_passed}" items, when the max number of'
+            f'allowed items are "{self.actual_allowed_params}"'
         )
 
     def __repr__(self):
-        return f"InvalidNumberOfArguments(number_of_params_passed={self.number_of_params_passed}, actual_allowed_params={self.actual_allowed_params}, param={self.param})"
+        return (
+            f"InvalidNumberOfArguments(number_of_params_passed={self.number_of_params_passed},"
+            f"actual_allowed_params={self.actual_allowed_params}, param={self.param})"
+        )

--- a/src/mapillary/models/exceptions.py
+++ b/src/mapillary/models/exceptions.py
@@ -355,3 +355,24 @@ class LiteralEnforcementException(MapillaryException):
             raise InvalidOptionError(
                 param=param, value=option_selected, options=options
             )
+
+class InvalidNumberOfArguments(MapillaryException):
+    """
+    Raised when an inappropriate number of parameters are passed to a function
+    """
+
+    def __init__(self, number_of_params_passed: int, actual_allowed_params: int, param: str,  *args: object) -> None:
+        super().__init__(*args)
+
+        self.number_of_params_passed = number_of_params_passed
+        self.actual_allowed_params = actual_allowed_params
+        self.param = param
+
+    def __str__(self):
+        return (
+            f'InvalidNumberOfArguments: The parameter, "{self.param}" was '
+            f'passed "{self.number_of_params_passed}" items, when the max number of allowed items are "{self.actual_allowed_params}"'
+        )
+
+    def __repr__(self):
+        return f"InvalidNumberOfArguments(number_of_params_passed={self.number_of_params_passed}, actual_allowed_params={self.actual_allowed_params}, param={self.param})"

--- a/src/mapillary/models/logger.py
+++ b/src/mapillary/models/logger.py
@@ -1,0 +1,86 @@
+# Copyright (c) Facebook, Inc. and its affiliates. (https://www.facebook.com)
+# Copyright (c) 2022 Mapillary, Inc. (https://www.mapillary.com)
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# -*- coding: utf-8 -*-
+
+"""
+mapillary.utils.logger
+~~~~~~~~~~~~~~~~~~~~~~
+
+This module implements the logger for mapillary, which is a wrapper of the logger package and
+the default configuration for each of the loggers per file.
+
+"""
+
+import logging
+import sys
+import os
+
+
+class Logger:
+
+    format_string: str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    level: int = logging.INFO
+
+    @staticmethod
+    def setup_logger(name: str, level: int = logging.INFO) -> logging.Logger:
+        """
+        Function setup as many loggers as you want. To be used at the top of the file.
+
+        Usage::
+
+            >>> Logger.setup_logger(name='mapillary.xxxx.yyyy', level=logging.INFO)
+            logger.Logger
+
+        :param name: The name of the logger
+        :type name: str
+
+        :param level: The level of the logger
+        :type level: int
+
+        :return: The logger object
+        :rtype: logging.Logger
+        """
+
+        # Basic logger setup
+        logger: Logger = logging.getLogger(name)
+
+        # stdout logger setup
+        stream_handler: logging.StreamHandler = logging.StreamHandler(sys.stdout)
+        logger.addHandler(stream_handler)
+
+        try:
+            logger.setLevel(level)
+        except ValueError:
+            logger.setLevel(logging.INFO)
+            logger.warning("LOG_LEVEL: Invalid variable - defaulting to: INFO")
+
+        # File logger setup
+        formatter: logging.Formatter = logging.Formatter(Logger.format_string)
+        handler: logging.FileHandler = logging.FileHandler(
+            Logger.get_os_log_path(name.split(".")[1] + ".log")
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+        return logger
+
+    @staticmethod
+    def get_os_log_path(log_file: str) -> str:
+        """
+        Get the path of the log file based on the OS
+
+        :param log_file: The name of the log file
+        :type log_file: str
+
+        :return: The path where the logs will be stored
+        :rtype: str
+        """
+
+        log_path: str = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs")
+
+        if not os.path.exists(log_path):
+            os.makedirs(log_path)
+
+        return os.path.join(log_path, log_file)

--- a/src/mapillary/utils/time.py
+++ b/src/mapillary/utils/time.py
@@ -14,6 +14,7 @@ the date filtering logic.
 
 # Package imports
 import datetime
+import re
 
 
 def date_to_unix_timestamp(date: str) -> int:
@@ -43,3 +44,20 @@ def date_to_unix_timestamp(date: str) -> int:
 
     # Return the epoch timestamp in miliseconds
     return int(datetime.datetime.fromisoformat(date).timestamp()) * 1000
+
+
+def is_iso8601_datetime_format(date_time: str) -> bool:
+    """
+    Checks if the date time is in ISO 8601 format
+
+    :param date_time: The date time to be checked
+    :type date_time: str
+
+    :return: True if the date time is in ISO 8601 format, else False
+    :rtype: bool
+    """
+
+    return (
+        re.match(r"(\d{4})\-(\d{2})\-(\d{2})T(\d{2})\:(\d{2})\:(\d{2})Z", date_time)
+        is not None
+    )

--- a/tests/config/__init__.py
+++ b/tests/config/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) Facebook, Inc. and its affiliates. (http://www.facebook.com)
+# -*- coding: utf-8 -*-
+
+"""
+mapillary.tests.config.__init__
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This module contains the tests for the config module from the src.
+
+- Copyright: (c) 2021 Facebook
+- License: MIT LICENSE
+"""
+
+from . import api  # noqa: F401

--- a/tests/config/api/__init__.py
+++ b/tests/config/api/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) Facebook, Inc. and its affiliates. (http://www.facebook.com)
+# -*- coding: utf-8 -*-
+
+"""
+mapillary.tests.config.api.__init__
+
+This package contains all the API v4 endpoints provided with the Mapillary Python SDK.
+
+- Copyright: (c) 2021 Facebook
+- License: MIT LICENSE
+"""
+
+from . import test_vector_tiles  # noqa: F401
+from . import test_entities  # noqa: F401
+from . import test_general  # noqa: F401

--- a/tests/config/api/test_entities.py
+++ b/tests/config/api/test_entities.py
@@ -1,0 +1,500 @@
+# Copyright (c) Facebook, Inc. and its affiliates. (http://www.facebook.com)
+# -*- coding: utf-8 -*-
+
+"""
+tests.config.api.test_entities
+
+This module tests the interface functions provided at src/mapillary/interface
+
+:copyright: (c) 2022 Facebook
+:license: MIT LICENSE
+"""
+
+# Package imports
+import datetime
+import logging
+from multiprocessing.sharedctypes import Value
+from mapillary.models.exceptions import InvalidFieldError
+import pytest
+
+# Local imports
+from mapillary.models.config import Config
+from mapillary.models.logger import Logger
+from mapillary.config.api.entities import Entities
+
+logger: logging.Logger = Logger.setup_logger(
+    name="mapillary.tests.config.api.test_entities"
+)
+
+
+@pytest.mark.parametrize(
+    "operation, expected",
+    [
+        (
+            (
+                "mly.config.api.entities.search_for_images(bbox=[62.22656249999999, 48.1640625,"
+                "38.41055825094609, 45.336701909968134])"
+            ),
+            (
+                "https://graph.mapillary.com/images?bbox=62.22656249999999,48.1640625,"
+                "38.41055825094609,45.336701909968134"
+            ),
+        )
+    ],
+)
+def test_search_for_images__only_bbox(operation, expected):
+
+    # Operation to test
+    test_that = f"{operation} == {expected}"
+
+    # Logging the intended operation to be tested
+    logger.info(f"[search_for_images] Test that {test_that}")
+
+    # Actual data on left, operation on right
+    actual: str = Entities.search_for_images(
+        bbox=[62.22656249999999, 48.1640625, 38.41055825094609, 45.336701909968134]
+    )
+
+    logger.info(f"[search_for_images] Actual: {actual}, Expected: {expected}")
+    # What was expected left, what was actual on the right
+    assert actual == expected, f"'{test_that}' failed, got {actual}"
+
+
+@pytest.mark.parametrize(
+    "operation, expected",
+    [
+        (
+            (
+                "mly.config.api.entities.search_for_images(bbox=[62.22656249999999, 48.1640625",
+                "38.41055825094609, 45.336701909968134], start_captured_at='2020-01-01T16:14:20Z'",
+                "end_captured_at='2021-01-01T16:14:20Z')",
+            ),
+            (
+                "https://graph.mapillary.com/images?bbox=62.22656249999999,48.1640625,"
+                "38.41055825094609,45.336701909968134&start_captured_at=2020-01-01T16:14:20Z&end_captured_at="
+                "2021-01-01T16:14:20Z"
+            ),
+        )
+    ],
+)
+def test_search_for_images__time_param(operation, expected):
+
+    # Operation to test
+    test_that = f"{operation} == {expected}"
+
+    # Logging the intended operation to be tested
+    logger.info(f"[search_for_images] Test that {test_that}")
+
+    # Actual data on left, operation on right
+    actual: str = Entities.search_for_images(
+        bbox=[62.22656249999999, 48.1640625, 38.41055825094609, 45.336701909968134],
+        start_captured_at="2020-01-01T16:14:20Z",
+        end_captured_at="2021-01-01T16:14:20Z",
+    )
+
+    logger.info(f"[search_for_images] Actual: {actual}, Expected: {expected}")
+    # What was expected left, what was actual on the right
+    assert actual == expected, f"'{test_that}' failed, got {actual}"
+
+
+@pytest.mark.parametrize(
+    "operation, expected",
+    [
+        (
+            (
+                "mly.config.api.entities.search_for_images(bbox=[62.22656249999999, 48.1640625,"
+                "38.41055825094609, 45.336701909968134],start_captured_at=datetime.datetime"
+                "(2020, 1, 1, 16, 14, 20),end_captured_at=datetime.datetime(2021, 1, 1, 16, 14,"
+                "20))"
+            ),
+            (
+                "https://graph.mapillary.com/images?bbox=62.22656249999999,48.1640625,"
+                "38.41055825094609,45.336701909968134&start_captured_at=2020-01-01T16:14:20Z&"
+                "end_captured_at=2021-01-01T16:14:20Z"
+            ),
+        )
+    ],
+)
+def test_search_for_images__time_param_datetime_object(operation, expected):
+
+    # Operation to test
+    test_that = f"{operation} == {expected}"
+
+    # Logging the intended operation to be tested
+    logger.info(f"[search_for_images] Test that {test_that}")
+
+    # Actual data on left, operation on right
+    actual: str = Entities.search_for_images(
+        bbox=[62.22656249999999, 48.1640625, 38.41055825094609, 45.336701909968134],
+        start_captured_at=datetime.datetime(2020, 1, 1, 16, 14, 20),
+        end_captured_at=datetime.datetime(2021, 1, 1, 16, 14, 20),
+    )
+
+    logger.info(f"[search_for_images] Actual: {actual}, Expected: {expected}")
+    # What was expected left, what was actual on the right
+    assert actual == expected, f"'{test_that}' failed, got {actual}"
+
+
+@pytest.mark.parametrize(
+    "operation, expected",
+    [
+        (
+            (
+                "mly.config.api.entities.search_for_images(bbox=[62.22656249999999, 48.1640625,"
+                "38.41055825094609, 45.336701909968134], start_captured_at='2020-01-01'",
+                "end_captured_at='2021-01-01T16:14:20Z')",
+            ),
+            ("ValueError: start_captured_at must be in ISO 8601 format"),
+        )
+    ],
+)
+def test_search_for_images__use_strict_invalid_start_time_param(operation, expected):
+
+    # Operation to test
+    test_that = f"{operation} == {expected}"
+
+    # Logging the intended operation to be tested
+    logger.info(f"[search_for_images] Test that {test_that}")
+
+    # Setting strict to True
+    Config.use_strict = True
+
+    has_exception_occurred: bool = False
+
+    # Actual data on left, operation on right
+    try:
+        actual: str = Entities.search_for_images(
+            bbox=[62.22656249999999, 48.1640625, 38.41055825094609, 45.336701909968134],
+            start_captured_at="2020-01-01",
+            end_captured_at="2021-01-01T16:14:20Z",
+        )
+    except ValueError:
+        has_exception_occurred = True
+
+    # What was expected left, what was actual on the right
+    assert has_exception_occurred, f"'{test_that}' failed, got {actual}"
+
+
+@pytest.mark.parametrize(
+    "operation, expected",
+    [
+        (
+            (
+                "mly.config.api.entities.search_for_images(bbox=[62.22656249999999, 48.1640625,"
+                "38.41055825094609, 45.336701909968134], start_captured_at='2020-01-01',"
+                "end_captured_at='2021-01-01T16:14:20Z')"
+            ),
+            (
+                "https://graph.mapillary.com/images?bbox=62.22656249999999,48.1640625,"
+                "38.41055825094609,45.336701909968134&end_captured_at=2021-01-01T16:14:20Z"
+            ),
+        )
+    ],
+)
+def test_search_for_images__without_use_strict_invalid_start_time_param(
+    operation, expected
+):
+
+    # Operation to test
+    test_that = f"{operation} == {expected}"
+
+    # Logging the intended operation to be tested
+    logger.info(f"[search_for_images] Test that {test_that}")
+
+    # Setting strict to False
+    Config.use_strict = False
+
+    # Actual data on left, operation on right
+    actual: str = Entities.search_for_images(
+        bbox=[62.22656249999999, 48.1640625, 38.41055825094609, 45.336701909968134],
+        start_captured_at="2020-01-01",
+        end_captured_at="2021-01-01T16:14:20Z",
+    )
+
+    logger.info(f"[search_for_images] Actual: {actual}, Expected: {expected}")
+    # What was expected left, what was actual on the right
+    assert actual == expected, f"'{test_that}' failed, got {actual}"
+
+
+@pytest.mark.parametrize(
+    "operation, expected",
+    [
+        (
+            (
+                "mly.config.api.entities.search_for_images(bbox=[62.22656249999999, 48.1640625,"
+                "38.41055825094609, 45.336701909968134], limit=100)"
+            ),
+            (
+                "https://graph.mapillary.com/images?bbox=62.22656249999999,48.1640625,"
+                "38.41055825094609,45.336701909968134&limit=100"
+            ),
+        )
+    ],
+)
+def test_search_for_images__limit_param(operation, expected):
+
+    # Operation to test
+    test_that = f"{operation} == {expected}"
+
+    # Logging the intended operation to be tested
+    logger.info(f"[search_for_images] Test that {test_that}")
+
+    # Actual data on left, operation on right
+    actual: str = Entities.search_for_images(
+        bbox=[62.22656249999999, 48.1640625, 38.41055825094609, 45.336701909968134],
+        limit=100,
+    )
+
+    logger.info(f"[search_for_images] Actual: {actual}, Expected: {expected}")
+    # What was expected left, what was actual on the right
+    assert actual == expected, f"'{test_that}' failed, got {actual}"
+
+
+@pytest.mark.parametrize(
+    "operation, expected",
+    [
+        (
+            (
+                "mly.config.api.entities.search_for_images(bbox=[62.22656249999999, 48.1640625,"
+                "38.41055825094609, 45.336701909968134], limit=2001)"
+            ),
+            (
+                "https://graph.mapillary.com/images?bbox=62.22656249999999,48.1640625,"
+                "38.41055825094609,45.336701909968134&limit=2000"
+            ),
+        )
+    ],
+)
+def test_search_for_images__exceeding_limit_param(operation, expected):
+
+    # Operation to test
+    test_that = f"{operation} == {expected}"
+
+    # Logging the intended operation to be tested
+    logger.info(f"[search_for_images] Test that {test_that}")
+
+    # Actual data on left, operation on right
+    actual: str = Entities.search_for_images(
+        bbox=[62.22656249999999, 48.1640625, 38.41055825094609, 45.336701909968134],
+        limit=2001,
+    )
+
+    logger.info(f"[search_for_images] Actual: {actual}, Expected: {expected}")
+    # What was expected left, what was actual on the right
+    assert actual == expected, f"'{test_that}' failed, got {actual}"
+
+
+@pytest.mark.parametrize(
+    "operation, expected",
+    [
+        (
+            (
+                "mly.config.api.entities.search_for_images(bbox=[62.22656249999999, 48.1640625,"
+                "38.41055825094609, 45.336701909968134], organization_id=0123456789)"
+            ),
+            (
+                "https://graph.mapillary.com/images?bbox=62.22656249999999,48.1640625,"
+                "38.41055825094609,45.336701909968134&organization_id=1234567890"
+            ),
+        )
+    ],
+)
+def test_search_for_images__organization_id_param(operation, expected):
+
+    # Operation to test
+    test_that = f"{operation} == {expected}"
+
+    # Logging the intended operation to be tested
+    logger.info(f"[search_for_images] Test that {test_that}")
+
+    # Actual data on left, operation on right
+    actual: str = Entities.search_for_images(
+        bbox=[62.22656249999999, 48.1640625, 38.41055825094609, 45.336701909968134],
+        organization_id=1234567890,
+    )
+
+    logger.info(f"[search_for_images] Actual: {actual}, Expected: {expected}")
+    # What was expected left, what was actual on the right
+    assert actual == expected, f"'{test_that}' failed, got {actual}"
+
+
+@pytest.mark.parametrize(
+    "operation, expected",
+    [
+        (
+            (
+                "mly.config.api.entities.search_for_images(bbox=[62.22656249999999, 48.1640625,"
+                "38.41055825094609, 45.336701909968134], organization_id=0123456789)"
+            ),
+            (
+                "https://graph.mapillary.com/images?bbox=62.22656249999999,48.1640625,"
+                "38.41055825094609,45.336701909968134&organization_id=1234567890"
+            ),
+        )
+    ],
+)
+def test_search_for_images__organization_id_param__as_str(operation, expected):
+
+    # Operation to test
+    test_that = f"{operation} == {expected}"
+
+    # Logging the intended operation to be tested
+    logger.info(f"[search_for_images] Test that {test_that}")
+
+    # Actual data on left, operation on right
+    actual: str = Entities.search_for_images(
+        bbox=[62.22656249999999, 48.1640625, 38.41055825094609, 45.336701909968134],
+        organization_id="1234567890",
+    )
+
+    logger.info(f"[search_for_images] Actual: {actual}, Expected: {expected}")
+    # What was expected left, what was actual on the right
+    assert actual == expected, f"'{test_that}' failed, got {actual}"
+
+
+@pytest.mark.parametrize(
+    "operation, expected",
+    [
+        (
+            (
+                "mly.config.api.entities.search_for_images(bbox=[62.22656249999999, 48.1640625,"
+                "38.41055825094609, 45.336701909968134], sequence_id=[1234567890, 9876543210,"
+                "1234567890, 9876543210])"
+            ),
+            (
+                "https://graph.mapillary.com/images?bbox=62.22656249999999,48.1640625,"
+                "38.41055825094609,45.336701909968134&sequence_id=1234567890,9876543210,"
+                "1234567890,9876543210"
+            ),
+        )
+    ],
+)
+def test_search_for_images__sequence_ids_param(operation, expected):
+
+    # Operation to test
+    test_that = f"{operation} == {expected}"
+
+    # Logging the intended operation to be tested
+    logger.info(f"[search_for_images] Test that {test_that}")
+
+    # Actual data on left, operation on right
+    actual: str = Entities.search_for_images(
+        bbox=[62.22656249999999, 48.1640625, 38.41055825094609, 45.336701909968134],
+        sequence_id=[1234567890, 9876543210, 1234567890, 9876543210],
+    )
+
+    logger.info(f"[search_for_images] Actual: {actual}, Expected: {expected}")
+    # What was expected left, what was actual on the right
+    assert actual == expected, f"'{test_that}' failed, got {actual}"
+
+
+@pytest.mark.parametrize(
+    "operation, expected",
+    [
+        (
+            (
+                "mly.config.api.entities.search_for_images(bbox=[62.22656249999999, 48.1640625,"
+                "38.41055825094609, 45.336701909968134], fields=['altitude', 'atomic_scale',"
+                "'camera_parameters'])"
+            ),
+            (
+                "https://graph.mapillary.com/images?bbox=62.22656249999999,48.1640625,"
+                "38.41055825094609,45.336701909968134&fields=altitude,atomic_scale,"
+                "camera_parameters,geometry"
+            ),
+        )
+    ],
+)
+def test_search_for_images__fields_param__selected(operation, expected):
+
+    # Operation to test
+    test_that = f"{operation} == {expected}"
+
+    # Logging the intended operation to be tested
+    logger.info(f"[search_for_images] Test that {test_that}")
+
+    # Actual data on left, operation on right
+    actual: str = Entities.search_for_images(
+        bbox=[62.22656249999999, 48.1640625, 38.41055825094609, 45.336701909968134],
+        fields=["altitude", "atomic_scale", "camera_parameters"],
+    )
+
+    logger.info(f"[search_for_images] Actual: {actual}, Expected: {expected}")
+    # What was expected left, what was actual on the right
+    assert actual == expected, f"'{test_that}' failed, got {actual}"
+
+
+@pytest.mark.parametrize(
+    "operation, expected",
+    [
+        (
+            (
+                "mly.config.api.entities.search_for_images(bbox=[62.22656249999999, 48.1640625,"
+                "38.41055825094609, 45.336701909968134], fields=['all'])"
+            ),
+            (
+                "https://graph.mapillary.com/images?bbox=62.22656249999999,48.1640625,"
+                "38.41055825094609,45.336701909968134&fields=altitude,atomic_scale,"
+                "camera_parameters,camera_type,captured_at,compass_angle,computed_altitude,"
+                "computed_compass_angle,computed_geometry,computed_rotation,exif_orientation,"
+                "geometry,height,thumb_256_url,thumb_1024_url,thumb_2048_url,merge_cc,mesh,"
+                "quality_score,sequence,sfm,width"
+            ),
+        )
+    ],
+)
+def test_search_for_images__fields_param__all(operation, expected):
+
+    # Operation to test
+    test_that = f"{operation} == {expected}"
+
+    # Logging the intended operation to be tested
+    logger.info(f"[search_for_images] Test that {test_that}")
+
+    # Actual data on left, operation on right
+    actual: str = Entities.search_for_images(
+        bbox=[62.22656249999999, 48.1640625, 38.41055825094609, 45.336701909968134],
+        fields=["all"],
+    )
+
+    logger.info(f"[search_for_images] Actual: {actual}, Expected: {expected}")
+    # What was expected left, what was actual on the right
+    assert actual == expected, f"'{test_that}' failed, got {actual}"
+
+
+@pytest.mark.parametrize(
+    "operation, expected",
+    [
+        (
+            (
+                "mly.config.api.entities.search_for_images(bbox=[62.22656249999999, 48.1640625,"
+                "38.41055825094609, 45.336701909968134], fields=['xxxx', 'yyyyyyyyyy'])"
+            ),
+            (
+                "InvalidFieldError: The invalid field, 'xxxx', was passed to the endpoint"
+                "'https://graph.mapillary.com/images?bbox=,:parameters=,:fields='"
+            ),
+        )
+    ],
+)
+def test_search_for_images__fields_param__all(operation, expected):
+
+    # Operation to test
+    test_that = f"{operation} == {expected}"
+
+    # Logging the intended operation to be tested
+    logger.info(f"[search_for_images] Test that {test_that}")
+
+    has_exception_occurred: bool = False
+
+    # Actual data on left, operation on right
+    try:
+        actual: str = Entities.search_for_images(
+            bbox=[62.22656249999999, 48.1640625, 38.41055825094609, 45.336701909968134],
+            fields=["xxxx", "yyyyyyyyyy"],
+        )
+    except InvalidFieldError:
+        has_exception_occurred = True
+
+    # What was expected left, what was actual on the right
+    assert has_exception_occurred, f"'{test_that}' failed, got {actual}"

--- a/tests/config/api/test_general.py
+++ b/tests/config/api/test_general.py
@@ -1,0 +1,11 @@
+# Copyright (c) Facebook, Inc. and its affiliates. (http://www.facebook.com)
+# -*- coding: utf-8 -*-
+
+"""
+tests.config.api.test_general
+
+This module tests the General class defined in the config package.
+
+:copyright: (c) 2022 Facebook
+:license: MIT LICENSE
+"""

--- a/tests/config/api/test_vector_tiles.py
+++ b/tests/config/api/test_vector_tiles.py
@@ -1,0 +1,11 @@
+# Copyright (c) Facebook, Inc. and its affiliates. (http://www.facebook.com)
+# -*- coding: utf-8 -*-
+
+"""
+tests.config.api.test_vector_tiles
+
+This module tests the Vector Tiles class defined in the config package.
+
+:copyright: (c) 2022 Facebook
+:license: MIT LICENSE
+"""


### PR DESCRIPTION
This PR,

* Adds `endpoint` per new API changes for batch processing `image_ids` and/or `detection_ids`
* Adds `.bat` file to replicate `Makefile` for Windows users - `Makefile` is limited only to `Linux` users
* Adds `endpoint` as per new API changes for the new `image_search` endpoint
* Adds `Config`, and `Logger` class for global variables in the SDK, and for generating a default logger configured object 
* Write `tests` for the `config/api/` module, specifically add tests only for `Entities` module at the moment
* Adds new functions in the `utils` module for SDK usage, adds function to `interface` to configure `Config` class