### PR TITLE
Fix Polygon creation in {shape,geojson}_features_controller

### DIFF
--- a/src/mapillary/controller/image.py
+++ b/src/mapillary/controller/image.py
@@ -582,19 +582,8 @@ def geojson_features_controller(
     # Extracting polygon from geojson, converting to dict
     polygon = geojson_to_polygon(geojson).to_dict()
 
-    # Generating a coordinates list to extract from polygon
-    coordinates_list = []
-
-    # Going through each feature
-    for feature in polygon["features"]:
-
-        # Going through the coordinate's nested list
-        for coordinates in feature["geometry"]["coordinates"][0]:
-            # Appending a tuple of coordinates
-            coordinates_list.append((coordinates[0], coordinates[1]))
-
-    # Sending coordinates_list a input to form a Polygon
-    polygon = Polygon(coordinates_list)
+    # Wrapping in Polygon object
+    polygon = Polygon(polygon["features"][0]["geometry"]["coordinates"])
 
     # Getting the boundary parameters from polygon
     boundary = shapely.geometry.shape(polygon)
@@ -765,19 +754,8 @@ def shape_features_controller(
 
     image_bbox_check(filters)
 
-    # Generating a coordinates list to extract from polygon
-    coordinates_list = []
-
-    # Going through each feature
-    for feature in shape["features"]:
-
-        # Going through the coordinate's nested list
-        for coordinates in feature["geometry"]["coordinates"][0]:
-            # Appending a tuple of coordinates
-            coordinates_list.append((coordinates[0], coordinates[1]))
-
-    # Sending coordinates_list a input to form a Polygon
-    polygon = Polygon(coordinates_list)
+    # Wrapping the shape in a Polygon object
+    polygon = Polygon(shape["features"][0]["geometry"]["coordinates"])
 
     # Getting the boundary parameters from polygon
     boundary = shapely.geometry.shape(polygon)


### PR DESCRIPTION
[shapely.geometry.shape](https://shapely.readthedocs.io/en/stable/manual.html?highlight=shape#shapely.geometry.shape) expects as input a GeoJSON-like mapping which, in the case of a polygon, should contain a list of lists of points. The current code instead tries to append all points to a single flat list. This causes errors such as:

```
Traceback (most recent call last):
  File "shapely/speedups/_speedups.pyx", line 252, in shapely.speedups._speedups.geos_linearring_from_py
AttributeError: 'list' object has no attribute '__array_interface__'
```

This PR fixes this issue.