### PR TITLE
Update filter.py

### DIFF
--- a/src/mapillary/utils/filter.py
+++ b/src/mapillary/utils/filter.py
@@ -342,7 +342,7 @@ def haversine_dist(data: dict, radius: float, coords: list, unit: str = "m") -> 
 
         # If the calculated haversince distance is less than the radius ...
         if (
-            haversine.haversine(coords, feature["geometry"]["coordinates"], unit=unit)
+            haversine.haversine(coords[::-1], feature["geometry"]["coordinates"][::-1], unit=unit)
             < radius
         ):
             # ... append to the output


### PR DESCRIPTION
haversine distance expects it's tuples to have latitude first and longitude second. Changing the order of the tuple results in incorrect values for the distance. I've flipped the lists from [lon, lat] to [lat, lon]