### PR TITLE
Update verify.py

### DIFF
--- a/src/mapillary/utils/verify.py
+++ b/src/mapillary/utils/verify.py
@@ -125,6 +125,7 @@ def image_check(kwargs) -> bool:
     return kwarg_check(
         kwargs=kwargs,
         options=[
+            "zoom",
             "min_captured_at",
             "max_captured_at",
             "radius",


### PR DESCRIPTION
Modified the image_check function to add the "zoom" to the options argument of kwarg_check. This is because in mapillary.interface, the following functions allow for zoom as a keyword argument:
1. get_image_looking_at_controller
2. get_image_close_to_controller 

The first line of these functions use image_check to filter through only the correct keys. Before the change, if zoom was supplied, image_check would throw an InvalidKwargError exception in both these functions.